### PR TITLE
Hide native dropdown marker on safari

### DIFF
--- a/compile_assets/scss/admonition.scss
+++ b/compile_assets/scss/admonition.scss
@@ -190,6 +190,14 @@ a.admonition-anchor-link {
 }
 
 summary.admonition-title {
+  details.admonition > & {
+    list-style: none;
+  }
+
+  details.admonition > &::-webkit-details-marker {
+    display: none;
+  }
+
   details.admonition > &::after {
     position: absolute;
     top: .625em;

--- a/compile_assets/scss/admonition.scss
+++ b/compile_assets/scss/admonition.scss
@@ -190,10 +190,6 @@ a.admonition-anchor-link {
 }
 
 summary.admonition-title {
-  details.admonition > & {
-    list-style: none;
-  }
-
   details.admonition > &::-webkit-details-marker {
     display: none;
   }


### PR DESCRIPTION
A collapsible admonish on safari gets a native drop-down marker as well as the one provided by mdbook-admonish:

<img width="835" alt="CleanShot 2023-08-05 at 17 19 51@2x" src="https://github.com/obmarg/mdbook-admonish/assets/556490/51252e98-de84-4758-bfc0-b8cf0a3c54f0">


It doesn't look very good - it's a bit out of alignment and out of place.  I checked on chrome and this element isn't even present there.

This adds some CSS to hide that element in safari, so it now looks the same as in chrome